### PR TITLE
fix pretest script & nyc config

### DIFF
--- a/lib/applySourceMap.js
+++ b/lib/applySourceMap.js
@@ -3,7 +3,7 @@ const applySourceMap = require('vinyl-sourcemaps-apply');
 const path = require('path');
 
 module.exports = function(file, result) {
-    // Apply source map to the chain
+	// Apply source map to the chain
 	if (file.sourceMap) {
 		const map = result.map.toJSON();
 		map.file = file.relative;

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "sugarss": "^1.0.0"
   },
   "devDependencies": {
-    "eslint": "^3.19.0",
+    "eslint": "^4.1.1",
     "from2-array": "0.0.4",
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "statements": 100,
     "functions": 100,
     "branches": 100,
-    "include": [
-      "lib/**/*.js"
-    ],
     "reporter": [
       "lcov",
       "text"
@@ -21,7 +18,7 @@
   "main": "lib/index.js",
   "scripts": {
     "coveralls": "coveralls < coverage/lcov.info",
-    "pretest": "eslint index.js",
+    "pretest": "eslint lib test",
     "test": "nyc mocha"
   },
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -29,8 +29,8 @@ it('should pass file when it isNull()', function (cb) {
 it('should transform css with multiple processors', function (cb) {
 
 	const stream = postcss(
-    [ asyncDoubler, objectDoubler() ]
-  );
+		[ asyncDoubler, objectDoubler() ]
+	);
 
 	stream.on('data', function (file) {
 		const result = file.contents.toString('utf8');
@@ -99,12 +99,12 @@ it('should generate source maps', function (cb) {
 	const init = sourceMaps.init();
 	const write = sourceMaps.write();
 	const css = postcss(
-    [ doubler, asyncDoubler ]
-  );
+		[ doubler, asyncDoubler ]
+	);
 
 	init
-    .pipe(css)
-    .pipe(write);
+		.pipe(css)
+		.pipe(write);
 
 	write.on('data', function (file) {
 		assert.equal(file.sourceMap.mappings, 'AAAA,IAAI,aAAY,CAAZ,aAAY,CAAZ,aAAY,CAAZ,YAAY,EAAE');
@@ -127,8 +127,8 @@ it('should correctly generate relative source map', function (cb) {
 
 	const init = sourceMaps.init();
 	const css = postcss(
-    [ doubler, doubler ]
-  );
+		[ doubler, doubler ]
+	);
 
 	init.pipe(css);
 
@@ -528,8 +528,8 @@ describe('<style> tag', function () {
 		}
 
 		const stream = postcss(
-      [ asyncDoubler, objectDoubler() ]
-    );
+			[ asyncDoubler, objectDoubler() ]
+		);
 
 		stream.on('data', function (file) {
 			const result = file.contents.toString('utf8');
@@ -552,8 +552,8 @@ describe('<style> tag', function () {
 		}
 
 		const stream = postcss(
-      [ asyncDoubler, objectDoubler() ]
-    );
+			[ asyncDoubler, objectDoubler() ]
+		);
 
 		stream.on('data', function (file) {
 			const result = file.contents.toString('utf8');


### PR DESCRIPTION
- Fix npm script of eslint.
- Remove non-essential nycconfiguration
 - format code use eslint v4